### PR TITLE
Add project-specific statuses

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -658,7 +658,13 @@ module WorkPackages
                                user_is_author?,
                                user_was_or_is_assignee?)
 
-      Status.where(id: workflows.select(:new_status_id))
+      statuses = Status.where(id: workflows.select(:new_status_id))
+
+      if model.project && model.project.allowed_statuses.exists?
+        statuses = statuses.where(id: model.project.allowed_statuses.select(:id))
+      end
+
+      statuses
     end
 
     def user_was_or_is_assignee?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -65,6 +65,9 @@ class Project < ApplicationRecord
   has_and_belongs_to_many :types, -> {
     order("#{::Type.table_name}.position")
   }
+  has_and_belongs_to_many :allowed_statuses,
+                          join_table: :projects_statuses,
+                          class_name: 'Status'
   has_many :work_packages, -> {
     order("#{WorkPackage.table_name}.created_at DESC")
       .includes(:status, :type)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -33,6 +33,8 @@ class Status < ApplicationRecord
   acts_as_list
 
   belongs_to :color, class_name: "Color"
+  has_and_belongs_to_many :projects,
+                          join_table: :projects_statuses
 
   before_destroy :delete_workflows
 
@@ -74,6 +76,10 @@ class Status < ApplicationRecord
   end
 
   def to_s; name end
+
+  def allowed_in_project?(project)
+    project.allowed_statuses.include?(self)
+  end
 
   def is_readonly
     return false unless can_readonly?

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -79,12 +79,17 @@ class Workflow < ApplicationRecord
 
   # Find potential statuses the user could be allowed to switch issues to
   def self.available_statuses(project, user = User.current)
-    Workflow
-      .includes(:new_status)
-      .where(role_id: user.roles_for_project(project).map(&:id))
-      .filter_map(&:new_status)
-      .uniq
-      .sort
+    statuses = Workflow
+               .includes(:new_status)
+               .where(role_id: user.roles_for_project(project).map(&:id))
+               .filter_map(&:new_status)
+               .uniq
+
+    if project.allowed_statuses.exists?
+      statuses &= project.allowed_statuses.to_a
+    end
+
+    statuses.sort
   end
 
   # Copies workflows from source to targets

--- a/db/migrate/20250428135734_create_projects_statuses.rb
+++ b/db/migrate/20250428135734_create_projects_statuses.rb
@@ -1,0 +1,11 @@
+class CreateProjectsStatuses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :projects_statuses, id: false do |t|
+      t.integer :project_id, null: false, default: 0
+      t.integer :status_id, null: false, default: 0
+    end
+
+    add_index :projects_statuses, :project_id, name: :projects_statuses_project_id
+    add_index :projects_statuses, %i[project_id status_id], name: :projects_statuses_unique, unique: true
+  end
+end

--- a/spec/models/project_status_association_spec.rb
+++ b/spec/models/project_status_association_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'Project status association' do
+  let!(:project) { create(:project) }
+  let!(:status1) { create(:status) }
+  let!(:status2) { create(:status) }
+
+  it 'links statuses to projects' do
+    project.allowed_statuses << status1
+    expect(project.allowed_statuses).to include(status1)
+    expect(project.allowed_statuses).not_to include(status2)
+  end
+
+  it 'filters workflow available statuses' do
+    role = create(:project_role)
+    user = create(:user)
+    create(:member, project: project, principal: user, roles: [role])
+    type = project.types.first
+
+    create(:workflow, old_status: status1, new_status: status2, role:, type:)
+
+    project.allowed_statuses << status2
+
+    expect(Workflow.available_statuses(project, user)).to include(status2)
+
+    project.allowed_statuses.delete(status2)
+    expect(Workflow.available_statuses(project, user)).not_to include(status2)
+  end
+end


### PR DESCRIPTION
## Summary
- create join table `projects_statuses`
- allow linking statuses to projects via `allowed_statuses`
- restrict workflow and work package contract to allowed statuses
- cover associations and filtering in a spec

## Testing
- `bundle exec rspec spec/models/project_status_association_spec.rb --format doc -fd` *(fails: rbenv: version `3.4.2` is not installed)*